### PR TITLE
Fix QuestionBuilder moving off the screen

### DIFF
--- a/ui/src/components/shared/editors/QuestionBuilder.js
+++ b/ui/src/components/shared/editors/QuestionBuilder.js
@@ -649,12 +649,6 @@ const QuestionBuilder = (props) => {
       <Modal
         open={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        style={{
-          position: "fixed",
-          top: "50%",
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-        }}
         size="large"
       >
         <Modal.Header>Question Form Builder</Modal.Header>


### PR DESCRIPTION
Fixed the issue with Question Builder moving off the screen due to CSS conflict with Semantic UI and in-line styling. 