### PR TITLE
Extract semester data in a more safe manner

### DIFF
--- a/ui/src/components/Tabs/AdminTab/ActionEditor/ActionTable.js
+++ b/ui/src/components/Tabs/AdminTab/ActionEditor/ActionTable.js
@@ -17,9 +17,9 @@ import GanttChart from "../../DashboardTab/TimelinesView/Timeline/GanttChart";
 export default function ActionTable(props) {
     // TODO: This is pretty inefficient and will get slower as more semesters are added - find better way to handle this.
     const semester = props.semesterData.find(semester => props.actions[0].semester === semester.semester_id)
-    const semesterName = semester.name
-    const semesterStart = semester.start_date
-    const semesterEnd = semester.end_date
+    const semesterName = semester?.name || "No Semester"
+    const semesterStart = semester?.start_date || ""
+    const semesterEnd = semester?.end_date || ""
     // const semesterName = props.semesterData.find(semester => props.actions[0].semester === semester.semester_id)?.name;
     const [open, setOpen] = React.useState('false');
     const [closeOnDocClick, setCloseOnDocClick] = useState(true);


### PR DESCRIPTION
This fixes bug where setting semester to "(No Semester)" crashes the admin Panel because the ActionTable is unable to load and therefore the entire page fails to load.

This should resolve this error when loading the Admin tab
![image](https://github.com/user-attachments/assets/98bee92c-6014-4bb1-8ce2-875f6599f2b1)
