### PR TITLE
Renamed "hidden" CSS class in helpers.css to "invisible"

### DIFF
--- a/server/server/database/test_data/page_html_dummy.sql
+++ b/server/server/database/test_data/page_html_dummy.sql
@@ -59,7 +59,7 @@ INSERT INTO page_html (name, html) VALUES
                  How will my organization benefit from sponsoring a Senior Project?
                </div>
                <div class="content">
-                 <p class="transition hidden"><ul>
+                 <p class="transition invisible"><ul>
                                      <li>Help educate the next generation of software engineers who you might want as employees</li>
                                      <li>
                                          Get the benefits of any work the team does in clarifying your problem, designing a solution,

--- a/ui/src/components/Tabs/AdminTab/ArchiveEditor/UniqueArchivePage.js
+++ b/ui/src/components/Tabs/AdminTab/ArchiveEditor/UniqueArchivePage.js
@@ -108,7 +108,7 @@ function UniqueProjectPage({ projectData }) {
               </div>
             )
           }
-          <div className="ui hidden divider"></div>
+          <div className="ui invisible divider"></div>
           <div className="ui relaxed centered grid">
             {project?.poster_thumb && (
               <img
@@ -184,7 +184,7 @@ function UniqueProjectPage({ projectData }) {
               </Modal.Actions>
             </Modal>
           </div>
-          <div className="ui hidden divider"></div>
+          <div className="ui invisible divider"></div>
           <div className="ui attached stackable padded grid">
             <div className="two column row">
               <div className="column">
@@ -211,7 +211,7 @@ function UniqueProjectPage({ projectData }) {
               </div>
             </div>
           </div>
-          <div className="ui hidden divider"></div>
+          <div className="ui invisible divider"></div>
           <div className="ui attached stackable padded grid">
             <div className="column">
               <div className="ui small header">Synopsis</div>

--- a/ui/src/components/Tabs/ProjectsTab/WebsiteViewerModal.js
+++ b/ui/src/components/Tabs/ProjectsTab/WebsiteViewerModal.js
@@ -193,7 +193,7 @@ export default function WebsiteViewerModal(props) {
                 </div>
               )
             }
-            <div className="ui hidden divider"></div>
+            <div className="ui invisible divider"></div>
             <div className="ui relaxed centered grid">
               {archive?.poster_thumb && (
                 <img
@@ -269,7 +269,7 @@ export default function WebsiteViewerModal(props) {
                 </Modal.Actions>
               </Modal>
             </div>
-            <div className="ui hidden divider"></div>
+            <div className="ui invisible divider"></div>
             <div className="ui attached stackable padded grid">
               <div className="two column row">
                 <div className="column">
@@ -296,7 +296,7 @@ export default function WebsiteViewerModal(props) {
                 </div>
               </div>
             </div>
-            <div className="ui hidden divider"></div>
+            <div className="ui invisible divider"></div>
             <div className="ui attached stackable padded grid">
               <div className="column">
                 <div className="ui small header">Synopsis</div>

--- a/ui/src/components/pages/HomePage.js
+++ b/ui/src/components/pages/HomePage.js
@@ -53,13 +53,13 @@ function HomePage() {
           />
         )}
       </div>
-      <div className="ui hidden divider"></div>
+      <div className="ui invisible divider"></div>
       <div className="ui divider"></div>
 
       <div className="row">
         <h2>Exemplary Projects</h2>
       </div>
-      <div className="ui hidden divider"></div>
+      <div className="ui invisible divider"></div>
       <div id="exemplaryProjectsDiv" style={{ marginBottom: "75px" }}>
         {/* <!-- Attach exemplary project elements here --> */}
         {projects.map((project, idx) => {

--- a/ui/src/components/pages/ProjectsPage.js
+++ b/ui/src/components/pages/ProjectsPage.js
@@ -77,7 +77,7 @@ function ProjectsPage() {
         <h2>Projects</h2>
       </div>
 
-      <div className="ui hidden divider"></div>
+      <div className="ui invisible divider"></div>
       <Input
         icon="search"
         iconPosition="left"
@@ -88,7 +88,7 @@ function ProjectsPage() {
         })}
       />
 
-      <div className="ui hidden divider"></div>
+      <div className="ui invisible divider"></div>
 
       <div id="exemplaryProjectsDiv">
         {/* <!-- Attach exemplary project elements here --> */}

--- a/ui/src/components/pages/ProposalPage.js
+++ b/ui/src/components/pages/ProposalPage.js
@@ -790,7 +790,7 @@ function ProposalPage() {
             standard Faculty Course Project Non-Disclosure Agreement which
             describes the same process for revealing proprietary information.
           </p>
-          <Divider hidden />
+          <Divider invisible />
           <br />
           <Radio
             label="Assignment of Limited Use Rights"
@@ -821,7 +821,7 @@ function ProposalPage() {
             Non-Disclosure Agreement which describes the same process for
             revealing proprietary information.
           </p>
-          <Divider hidden />
+          <Divider invisible />
           <br />
           <Radio
             label="Open Source Project"

--- a/ui/src/components/pages/UniqueProjectPage.js
+++ b/ui/src/components/pages/UniqueProjectPage.js
@@ -123,7 +123,7 @@ function UniqueProjectPage({ projectData }) {
               </div>
             )
           }
-          <div className="ui hidden divider"></div>
+          <div className="ui invisible divider"></div>
           <div className="ui relaxed centered grid">
             {project?.poster_thumb && (
               <img
@@ -199,7 +199,7 @@ function UniqueProjectPage({ projectData }) {
               </Modal.Actions>
             </Modal>
           </div>
-          <div className="ui hidden divider"></div>
+          <div className="ui invisible divider"></div>
           <div className="ui attached stackable padded grid">
             <div className="two column row">
               <div className="column">
@@ -226,7 +226,7 @@ function UniqueProjectPage({ projectData }) {
               </div>
             </div>
           </div>
-          <div className="ui hidden divider"></div>
+          <div className="ui invisible divider"></div>
           <div className="ui attached stackable padded grid">
             <div className="column">
               <div className="ui small header">Synopsis</div>

--- a/ui/src/css/utils/helpers.css
+++ b/ui/src/css/utils/helpers.css
@@ -4,7 +4,7 @@
   width: 100%;
 }
 
-.hidden {
+.invisible {
   visibility: collapse;
 }
 


### PR DESCRIPTION
This change is to differentiate the class in `helpers.css` used to hide HTML elements from the Semantic UI CSS class named `hidden`.