### PR TITLE
Fix #340: Sorting of "Projects" Tab Items for Coaches

### DIFF
--- a/ui/src/components/Tabs/ProjectsTab/Proposals.js
+++ b/ui/src/components/Tabs/ProjectsTab/Proposals.js
@@ -55,12 +55,12 @@ export default function Proposals(props) {
   useEffect(() => {
     const newProposalData = {
       proposals: props.proposalData,
-      column: COLUMNS.DATE,
-      direction: DESCENDING,
+      column: COLUMNS.SEMESTER,
     };
-    newProposalData.proposals = _.sortBy(newProposalData.proposals, [
-      COLUMNS.DATE,
-    ]);
+    newProposalData.proposals = _.sortBy(
+      newProposalData.proposals,
+      COLUMNS.SEMESTER,
+    ).reverse();
     setProposalData(newProposalData);
 
     // For All Projects view with user projects list, create simple permissions map


### PR DESCRIPTION
## Image:
<img width="1408" height="881" alt="coach david lee after" src="https://github.com/user-attachments/assets/e1ae164f-e421-44ea-98ad-883debe08673" />

## Issue:
- #340

## Cause:
- The sort in `Proposals.js` used `COLUMNS.DATE`, which doesn't exist in `COLUMNS`.
- `_.sortBy` with an undefined key doesn't do anything, so the rows just rendered in whatever order the API returned.

## Fix:
- Sort by `COLUMNS.SEMESTER`, and reverse for newest-first.

```javascript
newProposalData.proposals = _.sortBy(
  newProposalData.proposals,
  COLUMNS.SEMESTER,
).reverse();
```

## File Changed:
- `Proposals.js`

## Testing:
- Tested with mock accounts for all the coaches, and "My Projects" view now shows the newest semester first for each.
- Tested as an admin, including the "All Projects" view, which works as well.
- Verified the "Candidate Projects" view, since it shares the same component.
- Everything works as intended.
