### PR TITLE
Fix #374: Variety of User Circle Colors

### DIFF
--- a/ui/src/components/util/components/ProfileCircle.js
+++ b/ui/src/components/util/components/ProfileCircle.js
@@ -53,7 +53,7 @@ export default function ProfileCircle(props) {
       (acc, char) => acc + char.charCodeAt(0),
       0,
     );
-    const hue = hash % 360;
+    const hue = (hash * 58) % 360;
     return `hsl(${hue}, 70%, 70%)`;
   }
 


### PR DESCRIPTION
## Image:
<img width="1408" height="881" alt="Screenshot 2026-06-18 at 2 14 02 AM" src="https://github.com/user-attachments/assets/707a49cc-2207-4da5-b8c5-a2dbef74e6c3" />

## Issue:
- #374

## Cause:
- The function `randColorFromName` in `ProfileCircle.js` hashed the names by summing the char codes, and taking `% 360`.
- Most of the names summed to a similar range, so the modulo kept clumping the colors into green or brown, instead of spreading across the full color wheel.

## Fix:
- Multiply the hash by `58`, before the modulo to spread the hues evenly.
```javascript
const hue = (hash * 58) % 360;
```

## File Changed:
- `ProfileCircle.js`

## Testing:
- Tested with mock accounts for all the students, and coaches.
- The colors are now spread across the full color wheel, and the initials are still readable.
- Everything works as intended.
