### PR TITLE
Fix #376: Admin Users Receive "Failed to get Coach's Feedback" Alert on Students Tab in Production

### DIFF
--- a/ui/src/components/Tabs/StudentsTab/StudentsTab.js
+++ b/ui/src/components/Tabs/StudentsTab/StudentsTab.js
@@ -58,7 +58,10 @@ export default function StudentsTab(props) {
 
   function getCoachFeedback(project_id) {
     SecureFetch(`${config.url.API_GET_COACH_FEEDBACK}?project_id=${project_id}`)
-      .then((response) => response.json())
+      .then((response) => {
+        if (!response.ok) return [];
+        return response.json();
+      })
       .then((data) => {
         const submissions = {};
         data.forEach((s) => {
@@ -83,7 +86,7 @@ export default function StudentsTab(props) {
         updateCoachFeedback(project_id, forms);
       })
       .catch((error) => {
-        alert("Failed to get Coach's Feedback" + error);
+        console.error("Failed to get Coach's Feedback", error);
       });
   }
 


### PR DESCRIPTION
## Image:
- N/A

## Issue:
- #376

## Cause:
- The function `getCoachFeedback` in `StudentsTab.js` is called for every project when logged in as an admin.
- Some of those projects return a `404`, which comes back as an HTML error page instead of JSON.
- Calling `.json()` on that response throws, which lands in `.catch`, and fires the `alert`.

## Fix:
- Return early with an empty array, and swap `alert` for `console.error`.

```javascript
.then((response) => {
  if (!response.ok) return [];
  return response.json();
})
```

```javascript
.catch((error) => {
  console.error("Failed to get Coach's Feedback", error);
});
```

## File Changed:
- `StudentsTab.js`

## Testing:
- Everything works as intended.
