### PR TITLE
Fix #383: TypeError: Cannot Read Properties of Undefined (Reading 'start_date')

### DIFF
--- a/ui/src/components/Tabs/ProjectsTab/ProjectArchivePanel.js
+++ b/ui/src/components/Tabs/ProjectsTab/ProjectArchivePanel.js
@@ -250,6 +250,7 @@ export default function ProjectArchivePanel(props) {
             )
               .then((response) => response.json())
               .then((dates) => {
+                if (!dates?.length) return;
                 setInitialState((prevInitialState) => {
                   return {
                     ...prevInitialState,


### PR DESCRIPTION
## Image:
- N/A

## Issue:
- #383

## Cause:
- When a new archive is being created, the function `loadArchiveData` in `ProjectArchivePanel.js` calls `API_GET_START_AND_END_DATE` using the project's semester.
- If the API returns an empty array or `null`, `dates[0]` is undefined.
- Accessing `.start_date` on undefined throws a `TypeError`, and crashes the component.

## Fix:
- Return early if the response array is empty or false.

```javascript
.then((dates) => {
  if (!dates?.length) return;
  setInitialState((prevInitialState) => {
    return {
      ...prevInitialState,
      start_date: dates[0].start_date,
      end_date: dates[0].end_date,
      dept: "SE",
    };
  });
});
```

## File Changed:
- `ProjectArchivePanel.js`

## Testing:
- Everything works as intended.
