### PR TITLE
Fix #411

### DIFF
--- a/ui/src/components/Tabs/DashboardTab/TimelinesView/Timeline/ActionModal.js
+++ b/ui/src/components/Tabs/DashboardTab/TimelinesView/Timeline/ActionModal.js
@@ -1,4 +1,4 @@
-import React, { useContext, useRef, useState } from "react";
+import React, { useContext, useRef, useState, useEffect } from "react";
 import {
   Button,
   Form,
@@ -39,11 +39,22 @@ const camelCaseToSentence = (string = "") =>
   string.replaceAll(/([A-Z])/g, (word) => ` ${word}`).trimStart();
 
 export default function ActionModal(props) {
+  console.log("ActionModal rendered");
   const { user } = useContext(UserContext);
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(props.open || false);
   const [submissionModalOpen, setSubmissionModalOpen] = useState(
     MODAL_STATUS.CLOSED,
   );
+  useEffect(() => {
+    setOpen(props.open || false);
+    if (props.open) {
+      props.isOpenCallback?.(true);
+      fetchStudentNames();
+      setFormTouched(false);
+      setReadyToMark(false);
+      setTimeout(() => setReadyToMark(true), 250);
+    }
+  }, [props.open]);
   const [submissionModalResponse, setSubmissionModalResponse] = useState(
     "We were unable to receive your submission.",
   );
@@ -546,6 +557,12 @@ export default function ActionModal(props) {
           closeIcon={true}
           className={"sticky"}
           onClose={() => {
+            console.log("modal open");
+            setOpen(true);
+            props.isOpenCallback(true);
+            fetchStudentNames();
+            setFormTouched(false);
+            setReadyToMark(false);
             setTimeout(() => {
               if (formTouched && !props.viewOnly) {
                 openUnsavedModal(() => {
@@ -562,6 +579,7 @@ export default function ActionModal(props) {
             }, 0);
           }}
           onOpen={() => {
+            console.log("ACTION MODAL OPEN");
             setOpen(true);
             props.isOpenCallback(true);
             setFormTouched(false);
@@ -571,7 +589,12 @@ export default function ActionModal(props) {
           open={open}
           trigger={
             props.trigger || (
-              <Button ref={props.ref} fluid className="view-action-button">
+              <Button
+                ref={props.ref}
+                fluid
+                className="view-action-button"
+                onClick={() => console.log("trigger clicked")}
+              >
                 View Action
               </Button>
             )
@@ -658,6 +681,13 @@ export default function ActionModal(props) {
           closeIcon={true}
           className={"sticky"}
           onClose={() => {
+            console.log("modal open");
+            setOpen(true);
+            props.isOpenCallback(true);
+            fetchStudentNames();
+            setFormTouched(false);
+            setReadyToMark(false);
+            setTimeout(() => setReadyToMark(true), 250);
             setTimeout(() => {
               if (formTouched && !props.viewOnly) {
                 openUnsavedModal(() => {
@@ -674,6 +704,7 @@ export default function ActionModal(props) {
             }, 0);
           }}
           onOpen={() => {
+            console.log("ACTION MODAL OPEN");
             setOpen(true);
             props.isOpenCallback(true);
             fetchStudentNames();
@@ -684,7 +715,12 @@ export default function ActionModal(props) {
           open={open}
           trigger={
             props.trigger || (
-              <Button ref={props.ref} fluid className="view-action-button">
+              <Button
+                ref={props.ref}
+                fluid
+                className="view-action-button"
+                onClick={() => console.log("trigger clicked")}
+              >
                 View Action
               </Button>
             )

--- a/ui/src/components/Tabs/DashboardTab/TimelinesView/Timeline/ToolTip.js
+++ b/ui/src/components/Tabs/DashboardTab/TimelinesView/Timeline/ToolTip.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Icon, Popup } from "semantic-ui-react";
+import { Icon, Popup, Button } from "semantic-ui-react";
 import { ACTION_TARGETS, config } from "../../../../util/functions/constants";
 import { SecureFetch } from "../../../../util/functions/secureFetch";
 import {
@@ -29,6 +29,8 @@ export default function ToolTip(props) {
 
   const [submissions, setSubmissions] = useState(null);
   const [loadingSubmissions, setLoadingSubmissions] = useState(false);
+  const [actionModalOpen, setActionModalOpen] = useState(false);
+  const [popupOpen, setPopupOpen] = useState(false);
 
   var [hasMockedSubmission, setHasMockedSubmission] = useState(false);
 
@@ -62,6 +64,9 @@ export default function ToolTip(props) {
   // clicking elements on the modal
   let isOpenCallback = function (isOpen) {
     setCloseOnDocClick(!isOpen);
+    if (isOpen) {
+      setPopupOpen(false);
+    }
   };
 
   const loadSubmission = (projectId, actionId) => {
@@ -233,17 +238,19 @@ export default function ToolTip(props) {
          * However, action.state is based off of server time whereas if we parse action.start_date,
          * we need to deal with parsing with time zones and all of that.
          */}
-        {props.action?.action_target !== "break_period" ? (
-          <ActionModal
-            key={props.action?.action_id}
-            {...props.action}
-            isOpenCallback={isOpenCallback}
-            projectId={props.projectId}
-            preActionContent={metadata(true)}
-            reloadTimelineActions={props.reloadTimelineActions}
-          />
-        ) : (
-          <></>
+        {props.action?.action_target !== "break_period" && (
+          <Button
+            fluid
+            className="view-action-button"
+            onClick={(e) => {
+              console.log("VIEW ACTION CLICKED");
+              e.stopPropagation();
+              setPopupOpen(false);
+              setActionModalOpen(true);
+            }}
+          >
+            View Action
+          </Button>
         )}
       </div>
     );
@@ -259,33 +266,60 @@ export default function ToolTip(props) {
   }
 
   return (
-    <Popup
-      header={props.action?.action_title}
-      content={content()}
-      closeOnDocumentClick={closeOnDocClick}
-      closeOnEscape={true}
-      wide={hasMockedSubmission}
-      inverted={document.body.classList.contains("dark-mode")}
-      className="tool-pop"
-      offset={[offsetX, 0]}
-      trigger={props.trigger}
-      on="click"
-      onOpen={(event, data) => {
-        if (props.containerRef) {
-          try {
-            // purpose is to get the mouse's position relative to the start of the bar
-            let barOffset = data.trigger.ref.current.offsetLeft; // dist from bar start to gantt start
-            let containerScroll = props.containerRef?.current.scrollLeft; // dist from gantt start to left edge of visible container (scroll)
-            let mouseXWithinContainer =
-              event.clientX -
-              props.containerRef?.current.getBoundingClientRect().left; // mouse dist from left (within container)
-            setOffsetX(containerScroll - barOffset + mouseXWithinContainer);
-          } catch (e) {
-            console.log("tooltip positioning", e);
+    <>
+      <Popup
+        onClose={() => console.log("POPUP CLOSE")}
+        open={popupOpen}
+        header={props.action?.action_title}
+        content={content()}
+        closeOnDocumentClick={closeOnDocClick}
+        closeOnEscape={true}
+        wide={hasMockedSubmission}
+        inverted={document.body.classList.contains("dark-mode")}
+        className="tool-pop"
+        offset={[offsetX, 0]}
+        trigger={props.trigger}
+        on="click"
+        onOpen={(event, data) => {
+          console.log("POPUP OPEN");
+          setPopupOpen(true);
+          if (props.containerRef) {
+            try {
+              // purpose is to get the mouse's position relative to the start of the bar
+              let barOffset = data.trigger.ref.current.offsetLeft; // dist from bar start to gantt start
+              let containerScroll = props.containerRef?.current.scrollLeft; // dist from gantt start to left edge of visible container (scroll)
+              let mouseXWithinContainer =
+                event.clientX -
+                props.containerRef?.current.getBoundingClientRect().left; // mouse dist from left (within container)
+              setOffsetX(containerScroll - barOffset + mouseXWithinContainer);
+            } catch (e) {
+              console.log("tooltip positioning", e);
+            }
           }
-        }
-        loadSubmission(props.projectId, props.action?.action_id);
-      }}
-    />
+          loadSubmission(props.projectId, props.action?.action_id);
+        }}
+        onClose={(event, data) => {
+          console.log("POPUP CLOSE", event, data);
+          setPopupOpen(false);
+        }}
+      />
+      {props.action?.action_target !== "break_period" && (
+        <ActionModal
+          open={actionModalOpen}
+          key={props.action?.action_id}
+          {...props.action}
+          projectId={props.projectId}
+          preActionContent={metadata(true)}
+          reloadTimelineActions={props.reloadTimelineActions}
+          isOpenCallback={(isOpen) => {
+            setCloseOnDocClick(!isOpen);
+            if (isOpen) {
+              setActionModalOpen(false);
+            }
+            setActionModalOpen(isOpen);
+          }}
+        />
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Fixed an issue where clicking **View Action** from the timeline tooltip did not open the `ActionModal`.

## Changes

- Passed the controlled `open` state from `ToolTip` to `ActionModal`.
- Updated the modal state management to ensure it opens and closes correctly.
- Preserved the existing popup behavior when launching the modal.

## Testing

- Opened a timeline action.
- Clicked **View Action** from the tooltip.
- Verified that the `ActionModal` opens as expected.
- Verified that the `ActionModal` closes correctly.