### PR TITLE
Moved the Errors Tab to the Footer for Admins Only

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -8,6 +8,7 @@ import ProposalPage from "./components/pages/ProposalPage";
 import ErrorPage from "./components/pages/ErrorPage";
 import DashboardPage from "./components/pages/DashboardPage";
 import AuthErrorPage from "./components/pages/AuthErrorPage";
+import ErrorLogsPage from "./components/pages/ErrorLogsPage";
 import Header from "./components/shared/allPages/Header";
 import Footer from "./components/shared/allPages/Footer";
 import { UserContextProvider } from "./components/util/functions/UserContext";
@@ -37,6 +38,7 @@ function App() {
                 <Route path="/proposal-form" component={ProposalPage} />
                 <Route path="/dashboard" component={DashboardPage} />
                 <Route path="/auth-error" component={AuthErrorPage} />
+                <Route path="/error-logs" component={ErrorLogsPage} />
                 <Route path="/error" component={StackTraceErrorPage} />
                 <Route component={ErrorPage} />
               </Switch>

--- a/ui/src/components/pages/DashboardPage.js
+++ b/ui/src/components/pages/DashboardPage.js
@@ -6,7 +6,6 @@ import SemesterEditor from "../Tabs/AdminTab/SemesterEditor/SemesterEditor";
 import ActionEditor from "../Tabs/AdminTab/ActionEditor/ActionEditor";
 import StudentsTab from "../Tabs/StudentsTab/StudentsTab";
 import ProjectsTab from "../Tabs/ProjectsTab/ProjectsTab";
-import ErrorLogs from "../Tabs/ErrorsTab/ErrorLogs";
 import ProjectEditor from "../Tabs/AdminTab/ProjectEditor";
 import ActionLogs from "../Tabs/ActionSubmissionsTab/ActionLogs";
 import CoachesTab from "../Tabs/CoachesTab/CoachesTab";
@@ -23,9 +22,10 @@ import TimeLog from "../Tabs/TimeTrackingTab/TimeLog";
 import "./../../css/utils/helpers.css";
 
 export default function DashboardPage() {
-  const { user, setUser } = useContext(UserContext);
+  const { user, setUser, setIsAdminTabActive } = useContext(UserContext);
   const [semesterData, setSemestersData] = useState([]);
   const [authError, setAuthError] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
   const history = useHistory();
 
   // When dashboard loads, check who is currently signed in
@@ -102,26 +102,6 @@ export default function DashboardPage() {
   switch (user.role) {
     case "admin":
       if (!user.view_only && !user.mockUser.view_only) {
-        panes.push({
-          menuItem: {
-            key: "Errors-Tab",
-            content: (
-              <>
-                <i
-                  className="exclamation triangle icon"
-                  style={{ marginRight: 5 }}
-                />
-                Errors
-              </>
-            ),
-            href: "#",
-          },
-          render: () => (
-            <Tab.Pane>
-              <ErrorLogs />
-            </Tab.Pane>
-          ),
-        });
         panes.push({
           menuItem: {
             key: "Admin-Tab",
@@ -285,6 +265,15 @@ export default function DashboardPage() {
 
   panes.reverse();
 
+  useEffect(() => {
+    const activeKey = panes[activeIndex]?.menuItem?.key;
+    setIsAdminTabActive(activeKey === "Admin-Tab");
+  }, [activeIndex, user.role]);
+
+  useEffect(() => {
+    return () => setIsAdminTabActive(false);
+  }, []);
+
   // Don't render dashboard if there's an authentication error
   if (authError) {
     return null; // The useEffect will handle redirecting to auth-error page
@@ -294,7 +283,11 @@ export default function DashboardPage() {
     <>
       <AdminView />
       {/*This is for the tabs inside of the dashboard tab*/}
-      <Tab panes={panes} className="admin-menu" />
+      <Tab
+        panes={panes}
+        onTabChange={(e, data) => setActiveIndex(data.activeIndex)}
+        className="admin-menu"
+      />
     </>
   );
 }

--- a/ui/src/components/pages/ErrorLogsPage.js
+++ b/ui/src/components/pages/ErrorLogsPage.js
@@ -1,0 +1,111 @@
+import React, { useContext, useEffect, useState } from "react";
+import { Container, Button, Icon, Loader } from "semantic-ui-react";
+import { useHistory } from "react-router-dom";
+import { UserContext } from "../util/functions/UserContext";
+import { SecureFetch } from "../util/functions/secureFetch";
+import { config, USERTYPES } from "../util/functions/constants";
+import ErrorLogs from "../Tabs/ErrorsTab/ErrorLogs";
+import "./../../css/components/pages/ErrorLogsPage.css";
+
+function ErrorLogsPage() {
+  const { user, setUser } = useContext(UserContext);
+  const history = useHistory();
+  const [isLoadingUser, setIsLoadingUser] = useState(!user?.role);
+
+  useEffect(() => {
+    if (user?.role) {
+      setIsLoadingUser(false);
+      return;
+    }
+
+    SecureFetch(config.url.API_WHO_AM_I)
+      .then((response) => {
+        if (!response.ok) {
+          if (response.status === 401 || response.status === 403) {
+            history.push("/auth-error");
+            return;
+          }
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((responseUser) => {
+        if (!responseUser) return;
+
+        let parsedProfileInfo;
+        try {
+          parsedProfileInfo = responseUser.profile_info
+            ? JSON.parse(responseUser.profile_info.toString())
+            : { additional_info: "", dark_mode: false, gantt_view: true };
+        } catch (error) {
+          console.error("Error parsing profile_info:", error);
+          parsedProfileInfo = {
+            additional_info: "",
+            dark_mode: false,
+            gantt_view: true,
+          };
+        }
+        setUser({
+          user: responseUser.system_id,
+          role: responseUser.type,
+          fname: responseUser.fname,
+          lname: responseUser.lname,
+          semester_group: responseUser.semester_group,
+          project: responseUser.project,
+          isMock: Object.keys(responseUser.mock).length !== 0,
+          mockUser: responseUser.mock,
+          last_login: responseUser.last_login,
+          prev_login: responseUser.prev_login,
+          view_only: responseUser.view_only === "TRUE" ? true : false,
+          profile_info: parsedProfileInfo,
+        });
+        if (responseUser.system_id) {
+          const darkPref = ["1", "true"].includes(
+            parsedProfileInfo.dark_mode.toString().trim().toLowerCase(),
+          );
+          document.body.classList.toggle("dark-mode", darkPref);
+        }
+      })
+      .catch((error) => {
+        console.error("Authentication error:", error);
+        history.push("/auth-error");
+      })
+      .finally(() => setIsLoadingUser(false));
+  }, []);
+
+  const isAdmin =
+    user?.role === USERTYPES.ADMIN &&
+    !user?.view_only &&
+    !user?.mockUser?.view_only;
+
+  useEffect(() => {
+    if (!isLoadingUser && user?.role && !isAdmin) {
+      history.push("/dashboard");
+    }
+  }, [isLoadingUser, user, isAdmin, history]);
+
+  if (isLoadingUser) {
+    return <Loader active inline="centered" style={{ marginTop: "2rem" }} />;
+  }
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  return (
+    <Container>
+      <Button
+        basic
+        className="error-logs-back-button"
+        onClick={() => history.push("/dashboard")}
+        style={{ marginTop: "1rem" }}
+      >
+        <Icon name="arrow left" />
+        Back to Dashboard
+      </Button>
+      <ErrorLogs />
+    </Container>
+  );
+}
+
+export default ErrorLogsPage;

--- a/ui/src/components/shared/allPages/Footer.js
+++ b/ui/src/components/shared/allPages/Footer.js
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { UserContext } from "../../util/functions/UserContext";
-import { config } from "../../util/functions/constants";
+import { config, USERTYPES } from "../../util/functions/constants";
 import { SecureFetch } from "../../util/functions/secureFetch";
 import InnerHTML from "dangerously-set-html-content";
 import "./../../../css/containers/footer.css";
@@ -9,11 +10,17 @@ import uiConfig from "../../../config/uiConfig";
 import collegeLogo from "../../../Assets/gccis_logo.jpg";
 
 function Footer() {
-  const { user } = useContext(UserContext);
+  const { user, isAdminTabActive } = useContext(UserContext);
   const [footerHtml, setFooterHtml] = useState("");
   const [isLoading, setIsLoading] = useState(true);
 
   const signedIn = user && Object.keys(user).length > 0 && user.user;
+  const isFullAdmin =
+    signedIn &&
+    user.role === USERTYPES.ADMIN &&
+    !user.view_only &&
+    !user.mockUser?.view_only;
+  const showErrorLogsLink = isFullAdmin && isAdminTabActive;
   useEffect(() => {
     const footerName = signedIn ? "loggedInFooter" : "loggedOutFooter";
 
@@ -84,13 +91,17 @@ function Footer() {
           style={{ textAlign: "right" }}
         >
           <h5>
-            <a
-              href={uiConfig.footers.loggedIn.githubLink}
-              target="_blank"
-              rel="noreferrer"
-            >
-              v{uiConfig.footers.loggedIn.version}
-            </a>
+            {showErrorLogsLink ? (
+              <Link to="/error-logs">Error Logs</Link>
+            ) : (
+              <a
+                href={uiConfig.footers.loggedIn.githubLink}
+                target="_blank"
+                rel="noreferrer"
+              >
+                v{uiConfig.footers.loggedIn.version}
+              </a>
+            )}
           </h5>
         </div>
       )}

--- a/ui/src/components/util/functions/UserContext.js
+++ b/ui/src/components/util/functions/UserContext.js
@@ -5,11 +5,17 @@ import React, { createContext, useState } from "react";
  */
 
 // Use this to get the current state of a user
-export const UserContext = createContext({ user: null, setUser: () => {} });
+export const UserContext = createContext({
+  user: null,
+  setUser: () => {},
+  isAdminTabActive: false,
+  setIsAdminTabActive: () => {},
+});
 
 // Provider for the app -- you most likely don't need to touch this
 export function UserContextProvider({ children }) {
   const [user, updateUser] = useState({});
+  const [isAdminTabActive, setIsAdminTabActive] = useState(false);
 
   const setUser = (newUser) => {
     updateUser(newUser);
@@ -18,6 +24,8 @@ export function UserContextProvider({ children }) {
   let context = {
     user: user,
     setUser,
+    isAdminTabActive,
+    setIsAdminTabActive,
   };
 
   return (

--- a/ui/src/css/components/pages/ErrorLogsPage.css
+++ b/ui/src/css/components/pages/ErrorLogsPage.css
@@ -1,0 +1,11 @@
+.error-logs-back-button.ui.basic.button {
+  color: var(--text-primary) !important;
+  border: 1px solid var(--border-color) !important;
+  box-shadow: 0 0 0 1px var(--border-color) inset !important;
+  background: transparent !important;
+}
+
+.error-logs-back-button.ui.basic.button:hover {
+  background: var(--bg-hover) !important;
+  color: var(--text-primary) !important;
+}


### PR DESCRIPTION
## Image:
<img width="1408" height="881" alt="Screenshot 2026-07-26 at 12 09 36 PM" src="https://github.com/user-attachments/assets/c680ba46-9085-4c05-9b61-fc5649e43f23" />

## Issue:
- #417

## Cause:
- The `Errors` tab lived directly in the Admin dashboard's tab bar, making it too prominent and giving it more visual weight than it needed.
- There was no dedicated route for error logs, so access to them couldn't be scoped independently of the dashboard tabs.
- The footer's version link always pointed to GitHub for every signed-in role, with no way to surface an error logs shortcut for admins.

## Fix:
- Removed the `Errors` tab from the Admin dashboard's tab bar.
- Added a new `/error-logs` route rendering a dedicated `ErrorLogsPage`, restricted to full (non-view-only) admin accounts only.
- Updated the footer so it shows "Error Logs" (linking to `/error-logs`) only while a full admin is on the Admin tab; every other role/state keeps the normal GitHub version link.
- Added `isAdminTabActive` state to `UserContext` so the footer can be notified when the Admin tab becomes active, without making the dashboard's `Tab` component controlled (which had caused duplicate action buttons to render).
- `ErrorLogsPage` fetches "who am I" on mount so a hard browser refresh doesn't lose the signed-in user's context.
- Unauthorized signed-in users (students, coaches, view-only admins) who navigate to `/error-logs` directly are redirected to `/dashboard`, not the public homepage, so they never appear signed out.
- Added a "Back to Dashboard" button on the Error Logs page with theme-aware styling so it's visible in both light and dark mode.

```javascript
const isAdmin =
  user?.role === USERTYPES.ADMIN &&
  !user?.view_only &&
  !user?.mockUser?.view_only;

useEffect(() => {
  if (!isLoadingUser && user?.role && !isAdmin) {
    history.push("/dashboard");
  }
}, [isLoadingUser, user, isAdmin, history]);
```

```javascript
const isFullAdmin =
  signedIn &&
  user.role === USERTYPES.ADMIN &&
  !user.view_only &&
  !user.mockUser?.view_only;
const showErrorLogsLink = isFullAdmin && isAdminTabActive;
```

## Files Changed:
- `App.js`
- `DashboardPage.js`
- `Footer.js`
- `UserContext.js`
- `ErrorLogsPage.js` (new)
- `ErrorLogsPage.css` (new)

## Testing:
- Verified on a locally running instance as admin, view-only admin, coach, and student accounts.
- Confirmed the footer shows "Error Logs" only for full admins while on the Admin tab, and the normal GitHub link everywhere else, including view-only admins.
- Confirmed directly navigating to `/error-logs` as a student, coach, or view-only admin redirects to `/dashboard` while staying signed in, instead of landing on the homepage.
- Confirmed refreshing the browser while on `/error-logs` as a full admin no longer loses auth state or shows a blank page.
- Confirmed the "Back to Dashboard" button is visible in both light and dark mode.
- Everything works as intended.
