### PR TITLE
removed unnecessary color override

### DIFF
--- a/ui/src/css/utils/helpers.css
+++ b/ui/src/css/utils/helpers.css
@@ -14,14 +14,15 @@
   cursor: pointer;
 }
 
-.fake-div, button.fake-div {
+.fake-div,
+button.fake-div {
   text-align: start;
   line-height: 1.4285em;
   display: block;
   unicode-bidi: isolate;
   width: 100%;
 
-  background-color: rgba(0,0,0,0);
+  background-color: rgba(0, 0, 0, 0);
 
   border-block-style: none;
   border-inline-style: none;
@@ -158,7 +159,7 @@ a,
 
 .ui.form textarea:focus {
   background-color: var(--bg-primary);
-  color: var(--text-primary) !important;
+  color: var(--text-primary);
   box-shadow: none;
 }
 


### PR DESCRIPTION
There's an unneeded !important override for focused textboxes which sets the color to primary-color (black for light mode, white for dark mode.) This means that this issue also effects light mode, but wasn't as noticeable since the black text is readable.

The override seemed to have been added in a commit from Aug 5, 2025 titled "gantt chart and calendar now look more consistent", but I couldn't find a use-case where the !important was necessary so I will remove it.