### PR TITLE
457-low-contrast-scroll-bars-and-other-tools-in-dark-mode

### DIFF
--- a/ui/src/css/components/modal.css
+++ b/ui/src/css/components/modal.css
@@ -147,7 +147,7 @@ body.dark-mode .ui.dropdown {
 }
 
 body.dark-mode .ui.dropdown .menu {
-  background-color: var(--bg-footer-header);
+  background-color: var(--text-primary);
   border: 1px solid var(--border-color);
 }
 


### PR DESCRIPTION
Scroll wheel in dropdowns matched the background which hindered readability, so it now matches text-color in order to contrast.