### PR TITLE
353 potential edge case bug dropped team member makes some individual actions revert

### DIFF
--- a/server/server/routing/db_routes.js
+++ b/server/server/routing/db_routes.js
@@ -2934,7 +2934,7 @@ module.exports = (db) => {
                         WHEN action_target IS 'team' AND system_id IS NOT NULL THEN 'green'
                         WHEN action_target = 'peer_evaluation' AND COUNT(DISTINCT system_id) IS (SELECT COUNT(DISTINCT system_id) FROM users WHERE users.project = ?) + 1 THEN 'green'
                         WHEN action_target = 'peer_evaluation' THEN 'red'
-                        WHEN action_target IS 'individual' AND COUNT(DISTINCT system_id) IS (SELECT COUNT(DISTINCT system_id) FROM users WHERE users.project = ?) THEN 'green'
+                        WHEN action_target IS 'individual' AND NOT EXISTS (SELECT 1 FROM users u WHERE u.project = ? AND u.system_id NOT IN (SELECT action_log.system_id FROM action_log WHERE action_log.action_template = actions.action_id AND action_log.project = ?)) THEN 'green'
                         WHEN start_date <= date('now') AND due_date >= date('now') THEN 'yellow'
                         WHEN date('now') > due_date AND system_id IS NULL THEN 'red'
                         WHEN date('now') > due_date AND action_target IS 'individual' AND COUNT(DISTINCT system_id) != (SELECT COUNT(DISTINCT system_id) FROM users WHERE users.project = ?) THEN 'red'
@@ -2949,6 +2949,7 @@ module.exports = (db) => {
             GROUP BY actions.action_id`;
 
       db.query(getTimelineActions, [
+        req.query.project_id,
         req.query.project_id,
         req.query.project_id,
         req.query.project_id,

--- a/server/server/routing/db_routes.js
+++ b/server/server/routing/db_routes.js
@@ -2932,7 +2932,8 @@ module.exports = (db) => {
                         WHEN action_target IS 'admin' AND system_id IS NOT NULL THEN 'green'
                         WHEN action_target IS 'coach' AND system_id IS NOT NULL THEN 'green'
                         WHEN action_target IS 'team' AND system_id IS NOT NULL THEN 'green'
-                        WHEN action_target = 'peer_evaluation' AND COUNT(DISTINCT system_id) IS (SELECT COUNT(DISTINCT system_id) FROM users WHERE users.project = ?) + 1 THEN 'green'
+                        WHEN action_target = 'peer_evaluation' AND NOT EXISTS (SELECT 1 FROM users u WHERE u.project = ? AND u.system_id NOT IN (SELECT action_log.system_id FROM action_log WHERE action_log.action_template = actions.action_id AND action_log.project = ?)
+                        ) AND EXISTS (SELECT 1 FROM project_coaches pc JOIN action_log al ON al.system_id = pc.coach_id WHERE pc.project_id = ? AND al.action_template = actions.action_id AND al.project = ?) THEN 'green'
                         WHEN action_target = 'peer_evaluation' THEN 'red'
                         WHEN action_target IS 'individual' AND NOT EXISTS (SELECT 1 FROM users u WHERE u.project = ? AND u.system_id NOT IN (SELECT action_log.system_id FROM action_log WHERE action_log.action_template = actions.action_id AND action_log.project = ?)) THEN 'green'
                         WHEN start_date <= date('now') AND due_date >= date('now') THEN 'yellow'
@@ -2949,6 +2950,9 @@ module.exports = (db) => {
             GROUP BY actions.action_id`;
 
       db.query(getTimelineActions, [
+        req.query.project_id,
+        req.query.project_id,
+        req.query.project_id,
         req.query.project_id,
         req.query.project_id,
         req.query.project_id,


### PR DESCRIPTION
The bug has been resolved for both individual assignments and for peer reviews (the ones that were messed up)

Instead of comparing count, it now checks if it was completed by the current team members. This made the peer evals a bit more complicated since I had to actually check if the coach submitted instead of just having a +1. However, it also makes it so the bug doesn't pop up if a new member is added to a team as well, instead of just going off count being >= to team members