### PR TITLE
Added complete link functionality

### DIFF
--- a/ui/src/components/Tabs/ProjectsTab/ProjectViewerModal.js
+++ b/ui/src/components/Tabs/ProjectsTab/ProjectViewerModal.js
@@ -61,7 +61,9 @@ export default function ProjectViewerModal(props) {
       .then((archives) => {
         if (archives.length > 0) {
           if (archives[0].url_slug !== null && archives[0].url_slug !== "") {
-            setURL(archives[0].url_slug);
+            setURL(
+              `${window.location.origin}/projects/${archives[0].url_slug}`,
+            );
           }
         }
       });
@@ -102,7 +104,15 @@ export default function ProjectViewerModal(props) {
           <br />
         </div>
         <h3>Website</h3>
-        <b>URL:</b> {URL} <br />
+        <b>URL:</b>{" "}
+        {URL === "No URL found" ? (
+          URL
+        ) : (
+          <a href={URL} target="_blank">
+            {URL}
+          </a>
+        )}
+        <br />
         <h3>Sponsor Info</h3>
         <b>Organization:</b> {decode(props.project.organization || "")} <br />
         <b>Primary Contact:</b> {decode(props.project.primary_contact || "")}{" "}


### PR DESCRIPTION
The link gets built dependent on whichever source you're on the site from (localhost, sandbox, production)
<img width="626" height="83" alt="image" src="https://github.com/user-attachments/assets/cbae9e39-64ef-4999-97c1-8686c91ef474" />

If the link exists, it becomes clickable.
<img width="338" height="194" alt="image" src="https://github.com/user-attachments/assets/dd46c494-2ce5-4343-94bc-0cbef6cd6bbc" />
